### PR TITLE
Use standard command title naming convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "commands": [
             {
                 "command": "rust-mod-generator.createRustMod",
-                "title": "New a Rust module."
+                "title": "New Rust module"
             }
         ],
         "menus": {


### PR DESCRIPTION
I suggest changing the command title, removing the period and removing the "a" which is grammatically not correct.
This aligns the title with the first-party commands in VSCode. The commands / menu items to create files and folders are spelled like this: "New File", "New Folder" and "New Rust module" aligns better with that convention.