### PR TITLE
Move menu item below "New Folder"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
                 },
                 {
                     "when": "explorerResourceIsFolder && rust-mod-generator.customWhenClause",
-                    "group": "navigation",
+                    "group": "navigation@10",
                     "command": "rust-mod-generator.createRustMod"
                 }
             ]


### PR DESCRIPTION
The menu item on folders appears at the top of the menu by default, but I'd say it would be better positioned below the "New Folder" menu item. This PR specifies a [group-local order](https://code.visualstudio.com/api/references/contribution-points#Sorting-inside-groups) inside the `navigation` menu group.

Before:
<img width="296" alt="Top of the context menu for folders in the explorer panel with the highest up item being the one to create a new rust module" src="https://user-images.githubusercontent.com/7482056/154365690-c0ff3a2a-7d62-459f-85d3-f2e0dbfaac9a.png">

After:
<img width="290" alt="Top of the context menu for folders in the explorer panel with the item to create a new rust module directly under the one to create a new folder" src="https://user-images.githubusercontent.com/7482056/154365740-4cca2363-3b66-44ff-b169-1e0228d028e5.png">
