### PR TITLE
Add setting to hide menu item on files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This extension contributes the following settings:
 - `rust-mod-generator.autoFocus`: Enable to auto focus on the new created module.
 - `rust-mod-generator.selectAccessModifier`: Enable to set the access modifier when creating a new module.
 - `rust-mod-generator.addModDeclaration`: Enable to prepend `<modifier> mod <mod_name>;` to a resource file.
+- `rust-mod-generator.enableFileMenuItem`: Enable to show the context menu item on Rust files in addition to folders.
 
 ## Known Issues
 Welcome to post any issue.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable to prepend '<modifier> mod <mod_name>;' to the resource file. If this option is disabled, the option 'rust-mod-generator.selectAccessModifier' will be unavailable."
+                },
+                "rust-mod-generator.enableFileMenuItem": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable to show the context menu item on Rust files in addition to folders."
                 }
             }
         },
@@ -49,7 +54,7 @@
         "menus": {
             "explorer/context": [
                 {
-                    "when": "resourceLangId == rust",
+                    "when": "resourceLangId == rust && config.rust-mod-generator.enableFileMenuItem",
                     "group": "navigation",
                     "command": "rust-mod-generator.createRustMod"
                 },


### PR DESCRIPTION
This PR adds a setting (by default true, thus preserving the current behavior) with which the context menu item can be hidden on files. Initially I wanted to adjust the relative position in the group, like I did in #6 for the menu item on folders, but when I thought more about it I realized that I don't think I'd want it in that menu at all. That's why I added a setting to hide it. I believe this should be disabled by default (or maybe the menu item should be removed all together), since Visual Studio Code doesn't have "New File" and "New Folder" entries on the file context menu at all. So by convention I'd say it shouldn't be on there. If you agree with me, that it shouldn't be on there, please close this PR and I can submit a new one to remove the file menu item entirely.

This is how the file context menu looks like normally:
<img width="293" alt="Visual Studio Code context menu for files in the explorer pane" src="https://user-images.githubusercontent.com/7482056/154367774-1276e2ce-ee31-4bec-9fb2-031aa066ab9d.png">

